### PR TITLE
Qt: Update console widget text colors on theme change #fixes 1996

### DIFF
--- a/src/qt/pivx/settings/settingsconsolewidget.cpp
+++ b/src/qt/pivx/settings/settingsconsolewidget.cpp
@@ -290,6 +290,8 @@ SettingsConsoleWidget::SettingsConsoleWidget(PIVXGUI* _window, QWidget *parent) 
     RPCSetTimerInterfaceIfUnset(rpcTimerInterface);
 
     startExecutor();
+    QString theme;
+    updateTextColors(isLightTheme(), theme);
     clear();
 }
 
@@ -348,8 +350,11 @@ bool SettingsConsoleWidget::eventFilter(QObject* obj, QEvent* event)
                     QApplication::postEvent(ui->lineEdit, new QKeyEvent(*keyevt));
                     return true;
                 }
-                if (mod == Qt::ControlModifier && key == Qt::Key_L)
+                if (mod == Qt::ControlModifier && key == Qt::Key_L) {
+                    QString theme;
+                    updateTextColors(isLightTheme(), theme);
                     clear(false);
+                }
         }
     }
     return QWidget::eventFilter(obj, event);
@@ -415,9 +420,6 @@ void SettingsConsoleWidget::clear(bool clearHistory)
                 QUrl(ICON_MAPPING[i].url),
                 QImage(ICON_MAPPING[i].source));
     }
-
-    QString theme;
-    changeTheme(isLightTheme(), theme);
 
 #ifdef Q_OS_MAC
     QString clsKey = "(⌘)-L";
@@ -545,8 +547,7 @@ void SettingsConsoleWidget::scrollToEnd()
     scrollbar->setValue(scrollbar->maximum());
 }
 
-
-void SettingsConsoleWidget::changeTheme(bool isLightTheme, QString &theme)
+void SettingsConsoleWidget::updateTextColors(bool isLightTheme, QString &theme)
 {
     // Set default style sheet
     if (isLightTheme) {
@@ -569,6 +570,12 @@ void SettingsConsoleWidget::changeTheme(bool isLightTheme, QString &theme)
                 "b { color: #FFFFFF; } ");
     }
     updateStyle(ui->messagesWidget);
+}
+
+void SettingsConsoleWidget::changeTheme(bool isLightTheme, QString &theme)
+{
+    updateTextColors(isLightTheme, theme);
+    clear(false);
 }
 
 void SettingsConsoleWidget::onCommandsClicked()

--- a/src/qt/pivx/settings/settingsconsolewidget.cpp
+++ b/src/qt/pivx/settings/settingsconsolewidget.cpp
@@ -290,7 +290,6 @@ SettingsConsoleWidget::SettingsConsoleWidget(PIVXGUI* _window, QWidget *parent) 
     RPCSetTimerInterfaceIfUnset(rpcTimerInterface);
 
     startExecutor();
-    QString theme;
     updateTextColors(isLightTheme());
     clear();
 }
@@ -351,7 +350,6 @@ bool SettingsConsoleWidget::eventFilter(QObject* obj, QEvent* event)
                     return true;
                 }
                 if (mod == Qt::ControlModifier && key == Qt::Key_L) {
-                    QString theme;
                     updateTextColors(isLightTheme());
                     clear(false);
                 }

--- a/src/qt/pivx/settings/settingsconsolewidget.cpp
+++ b/src/qt/pivx/settings/settingsconsolewidget.cpp
@@ -291,7 +291,7 @@ SettingsConsoleWidget::SettingsConsoleWidget(PIVXGUI* _window, QWidget *parent) 
 
     startExecutor();
     QString theme;
-    updateTextColors(isLightTheme(), theme);
+    updateTextColors(isLightTheme());
     clear();
 }
 
@@ -352,7 +352,7 @@ bool SettingsConsoleWidget::eventFilter(QObject* obj, QEvent* event)
                 }
                 if (mod == Qt::ControlModifier && key == Qt::Key_L) {
                     QString theme;
-                    updateTextColors(isLightTheme(), theme);
+                    updateTextColors(isLightTheme());
                     clear(false);
                 }
         }
@@ -547,7 +547,7 @@ void SettingsConsoleWidget::scrollToEnd()
     scrollbar->setValue(scrollbar->maximum());
 }
 
-void SettingsConsoleWidget::updateTextColors(bool isLightTheme, QString &theme)
+void SettingsConsoleWidget::updateTextColors(bool isLightTheme)
 {
     // Set default style sheet
     if (isLightTheme) {
@@ -574,7 +574,7 @@ void SettingsConsoleWidget::updateTextColors(bool isLightTheme, QString &theme)
 
 void SettingsConsoleWidget::changeTheme(bool isLightTheme, QString &theme)
 {
-    updateTextColors(isLightTheme, theme);
+    updateTextColors(isLightTheme);
     clear(false);
 }
 

--- a/src/qt/pivx/settings/settingsconsolewidget.h
+++ b/src/qt/pivx/settings/settingsconsolewidget.h
@@ -72,7 +72,7 @@ private:
     QCompleter *autoCompleter;
 
     void startExecutor();
-    void updateTextColors(bool isLightTheme, QString &theme);
+    void updateTextColors(bool isLightTheme);
 
 private Q_SLOTS:
     void on_lineEdit_returnPressed();

--- a/src/qt/pivx/settings/settingsconsolewidget.h
+++ b/src/qt/pivx/settings/settingsconsolewidget.h
@@ -72,6 +72,7 @@ private:
     QCompleter *autoCompleter;
 
     void startExecutor();
+    void updateTextColors(bool isLightTheme, QString &theme);
 
 private Q_SLOTS:
     void on_lineEdit_returnPressed();


### PR DESCRIPTION
###What does it do?
Update text colors, cleat the screen and reprint welcome message when the theme is changed. Remove misleading changeTheme call from clear, so that button named Clear only clears the screen and reprints welcome message, but doesn't change color of the text.

Demonstation:
https://user-images.githubusercontent.com/22178604/109415073-2fa52a80-79bf-11eb-95a3-aaea4fe6bb39.mp4

###What else do you need to know?
We can't change the color of already printed text in QTextEdit - changes are applied only to newly displayed text. So, I considered several approaches to fix this issue:
- save all the text that will be displayed in console and reprint it on theme change;
- read all the printed text, clear the screen, change colors and then reprint the text;
- clear the screen on theme change and just print welcome message.

The last option seems to be the most reasonable. I also considered adding information message (informing that screen will be cleared) when user tries to change theme while settings console widget is open, but as the themeChanged signal is emitted starting from TopBar, it looks like not the best thing to make objects of TopBar or PIVXGUI know about visibility status of settingsConsoleWidget.