### PR TITLE
Qt: Set fee to highest possible if input is too big #fixes 2234

### DIFF
--- a/src/qt/pivx/sendcustomfeedialog.cpp
+++ b/src/qt/pivx/sendcustomfeedialog.cpp
@@ -123,6 +123,7 @@ void SendCustomFeeDialog::accept()
     // Check insane fee
     const CAmount insaneFee = ::minRelayTxFee.GetFeePerK() * 10000;
     if (customFee >= insaneFee) {
+        ui->lineEditCustomFee->setText(BitcoinUnits::format(walletModel->getOptionsModel()->getDisplayUnit(), insaneFee - CWallet::GetRequiredFee(1000)));
         inform(tr("Fee too high. Must be below: %1").arg(
                 BitcoinUnits::formatWithUnit(walletModel->getOptionsModel()->getDisplayUnit(), insaneFee)));
     } else if (customFee < CWallet::GetRequiredFee(1000)) {


### PR DESCRIPTION
Set custom transaction fee to highest possible value in case input is too big number.
![2](https://user-images.githubusercontent.com/22178604/110345513-5276b500-8037-11eb-9e52-34582d22ae97.png)
