### PR TITLE
Qt: Change receiving address label text #fixes 1637

### DIFF
--- a/src/qt/pivx/forms/send.ui
+++ b/src/qt/pivx/forms/send.ui
@@ -255,7 +255,7 @@ padding-top:2px;
              <string notr="true">margin-left:8px;</string>
             </property>
             <property name="text">
-             <string>PIVX address or contact label</string>
+             <string>Receiving address</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Change text of the receiving address label from "PIVX address or contact label" to "Receiving address".
![3](https://user-images.githubusercontent.com/22178604/110354557-f9ac1a00-8040-11eb-8d78-064b3f5ff8db.png)
