### PR TITLE
Inform about necessity of app restart on connection loss #fixes 1839

### DIFF
--- a/src/guiinterface.h
+++ b/src/guiinterface.h
@@ -88,6 +88,9 @@ public:
     /** Number of network connections changed. */
     boost::signals2::signal<void(int newNumConnections)> NotifyNumConnectionsChanged;
 
+    /** Network connection has been lost. */
+    boost::signals2::signal<void()> NotifyConnectionLost;
+
     /** New, updated or cancelled alert. */
     boost::signals2::signal<void()> NotifyAlertChanged;
 

--- a/src/net.h
+++ b/src/net.h
@@ -291,6 +291,8 @@ private:
     void ThreadSocketHandler();
     void ThreadDNSAddressSeed();
 
+    void CheckConnectionAvailable();
+
     void WakeMessageHandler();
 
     uint64_t CalculateKeyedNetGroup(const CAddress& ad);

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -181,6 +181,11 @@ void ClientModel::updateNumConnections(int numConnections)
     Q_EMIT numConnectionsChanged(numConnections);
 }
 
+void ClientModel::notifyLostConnection()
+{
+    Q_EMIT connectionLost();
+}
+
 void ClientModel::updateAlert()
 {
     Q_EMIT alertsChanged(getStatusBarWarnings());
@@ -295,6 +300,11 @@ static void NotifyNumConnectionsChanged(ClientModel* clientmodel, int newNumConn
         Q_ARG(int, newNumConnections));
 }
 
+static void NotifyConnectionLost(ClientModel* clientmodel)
+{
+    QMetaObject::invokeMethod(clientmodel, "notifyLostConnection", Qt::QueuedConnection);
+}
+
 static void NotifyAlertChanged(ClientModel* clientmodel)
 {
     qDebug() << "NotifyAlertChanged";
@@ -312,6 +322,7 @@ void ClientModel::subscribeToCoreSignals()
     // Connect signals to client
     m_handler_show_progress = interfaces::MakeHandler(uiInterface.ShowProgress.connect(std::bind(ShowProgress, this, std::placeholders::_1, std::placeholders::_2)));
     m_handler_notify_num_connections_changed = interfaces::MakeHandler(uiInterface.NotifyNumConnectionsChanged.connect(std::bind(NotifyNumConnectionsChanged, this, std::placeholders::_1)));
+    m_handler_notify_connection_lost = interfaces::MakeHandler(uiInterface.NotifyConnectionLost.connect(std::bind(NotifyConnectionLost, this)));
     m_handler_notify_alert_changed = interfaces::MakeHandler(uiInterface.NotifyAlertChanged.connect(std::bind(NotifyAlertChanged, this)));
     m_handler_banned_list_changed = interfaces::MakeHandler(uiInterface.BannedListChanged.connect(std::bind(BannedListChanged, this)));
     m_handler_notify_block_tip = interfaces::MakeHandler(uiInterface.NotifyBlockTip.connect(std::bind(BlockTipChanged, this, std::placeholders::_1, std::placeholders::_2)));

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -101,6 +101,7 @@ private:
     // Listeners
     std::unique_ptr<interfaces::Handler> m_handler_show_progress;
     std::unique_ptr<interfaces::Handler> m_handler_notify_num_connections_changed;
+    std::unique_ptr<interfaces::Handler> m_handler_notify_connection_lost;
     std::unique_ptr<interfaces::Handler> m_handler_notify_alert_changed;
     std::unique_ptr<interfaces::Handler> m_handler_banned_list_changed;
     std::unique_ptr<interfaces::Handler> m_handler_notify_block_tip;
@@ -126,6 +127,7 @@ private:
 
 Q_SIGNALS:
     void numConnectionsChanged(int count);
+    void connectionLost();
     void numBlocksChanged(int count);
     void strMasternodesChanged(const QString& strMasternodes);
     void alertsChanged(const QString& warnings);
@@ -141,6 +143,7 @@ public Q_SLOTS:
     void updateTimer();
     void updateMnTimer();
     void updateNumConnections(int numConnections);
+    void notifyLostConnection();
     void updateAlert();
     void updateBanlist();
 };

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -421,6 +421,8 @@ void TopBar::loadClientModel()
         setNumConnections(clientModel->getNumConnections());
         connect(clientModel, &ClientModel::numConnectionsChanged, this, &TopBar::setNumConnections);
 
+        connect(clientModel, &ClientModel::connectionLost, this, &TopBar::informConnectionLost);
+
         setNumBlocks(clientModel->getNumBlocks());
         connect(clientModel, &ClientModel::numBlocksChanged, this, &TopBar::setNumBlocks);
 
@@ -466,6 +468,11 @@ void TopBar::setNumConnections(int count)
     }
 
     ui->pushButtonConnection->setButtonText(tr("%n active connection(s)", "", count));
+}
+
+void TopBar::informConnectionLost()
+{
+    inform("Network connection is lost. Please, restart application.");
 }
 
 void TopBar::setNumBlocks(int count)

--- a/src/qt/pivx/topbar.h
+++ b/src/qt/pivx/topbar.h
@@ -47,6 +47,7 @@ public Q_SLOTS:
     void updateDisplayUnit();
 
     void setNumConnections(int count);
+    void informConnectionLost();
     void setNumBlocks(int count);
     void setStakingStatusActive(bool fActive);
     void updateStakingStatus();


### PR DESCRIPTION
Check for network connection availability every 3 minutes. In case connection is lost, show information message about necessity of application restart (respectively, every 3 minutes).
Connection loss should also be reflected on topbar icon, information window and console command, but it is topic for another feature request.
![connection](https://user-images.githubusercontent.com/22178604/110713120-07f96200-820a-11eb-83cd-4d99de70b747.png)